### PR TITLE
Run flake8-nb even if flake8 fails

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -20,5 +20,6 @@ jobs:
       run: |
         find . -type f -name "*.py" | xargs flake8
     - name: run flake8-notebook ⚙️
+      if: '!cancelled()'
       run: |
         find . -type f -name "*.ipynb" | xargs flake8-nb


### PR DESCRIPTION
# Description
Runs flake8 for notebooks even if the flake8 failed

# Changes Made
Run flake8-nb unless workflow is cancelled

# Related Issues
<!-- If this pull request resolves any GitHub issues, reference them here -->

# Additional Notes
<!-- Any additional information or context about the pull request -->
