### PR TITLE
Precommit CI Integration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,12 +1,10 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: ""
 labels: bug
-assignees: ''
-
+assignees: ""
 ---
-
 
 **Description**
 A clear and concise description of what the bug is.
@@ -21,9 +19,10 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Environment**
- - OS:
- - Python version:
- - Python env/venv: 
+
+- OS:
+- Python version:
+- Python env/venv:
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/documentation_issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.md
@@ -1,10 +1,9 @@
 ---
 name: Documentation issue
 about: Create a report to improve documenation
-title: ''
+title: ""
 labels: documentation
-assignees: ''
-
+assignees: ""
 ---
 
 **Description**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,12 +1,10 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
+title: ""
 labels: enhancement
-assignees: ''
-
+assignees: ""
 ---
-
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,15 @@
 # Description
+
 <!-- Describe the purpose of this pull request -->
 
 # Changes Made
+
 <!-- Provide a brief overview of the changes implemented in this pull request -->
 
 # Related Issues
+
 <!-- If this pull request resolves any GitHub issues, reference them here -->
 
 # Additional Notes
+
 <!-- Any additional information or context about the pull request -->

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,25 +1,25 @@
 name: flake8 ⚙️
 
-on: [ push, pull_request ]
+on: [push, pull_request]
 
 jobs:
   main:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Setup Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-        architecture: x64
-    - name: Checkout repository
-      uses: actions/checkout@master
-    - name: Install flake8
-      run: pip install flake8 flake8-nb
-    - name: run flake8 ⚙️
-      run: |
-        find . -type f -name "*.py" | xargs flake8
-    - name: run flake8-notebook ⚙️
-      if: '!cancelled()'
-      run: |
-        find . -type f -name "*.ipynb" | xargs flake8-nb
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+          architecture: x64
+      - name: Checkout repository
+        uses: actions/checkout@master
+      - name: Install flake8
+        run: pip install flake8 flake8-nb
+      - name: run flake8 ⚙️
+        run: |
+          find . -type f -name "*.py" | xargs flake8
+      - name: run flake8-notebook ⚙️
+        if: "!cancelled()"
+        run: |
+          find . -type f -name "*.ipynb" | xargs flake8-nb

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,48 @@
+minimum_pre_commit_version: "2.9.0"
+ci:
+  autoupdate_schedule: monthly
+repos:
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
+  - repo: local
+    hooks:
+      - id: forbid-symlinks
+        name: Forbid symlinks
+        entry: Forbid symlinks
+        language: fail
+        types: [symlink]
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.1
+    hooks:
+      - id: forbid-crlf
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: destroyed-symlinks
+      - id: detect-private-key
+      - id: end-of-file-fixer
+        exclude_types: [svg]
+      - id: fix-byte-order-marker
+      - id: mixed-line-ending
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v4.0.0-alpha.8"
+    hooks:
+      - id: prettier
+  - repo: https://github.com/ikamensh/flynt
+    rev: "1.0.1"
+    hooks:
+      - id: flynt
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.1
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,8 +44,14 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
-        types_or: [ python, pyi, jupyter ]
-        args: [ --fix ]
+        types_or: [python, pyi, jupyter]
+        args: [--fix]
       # Run the formatter.
       - id: ruff-format
-        types_or: [ python, pyi, jupyter ]
+        types_or: [python, pyi, jupyter]
+  # Remove stale jupyter notebook outputs
+  # For extra options see https://github.com/kynan/nbstripout?tab=readme-ov-file#configuration-files
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.7.1
+    hooks:
+      - id: nbstripout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,8 +41,13 @@ repos:
     hooks:
       - id: flynt
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.1
+    # Ruff version.
+    rev: v0.5.0
     hooks:
+      # Run the linter.
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        types_or: [ python, pyi, jupyter ]
+        args: [ --fix ]
+      # Run the formatter.
       - id: ruff-format
+        types_or: [ python, pyi, jupyter ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ ci:
 repos:
   - repo: meta
     hooks:
-      - id: check-hooks-apply
       - id: check-useless-excludes
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-      - id: check-added-large-files
       - id: check-case-conflict
       - id: check-executables-have-shebangs
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # CGS Repository Template
+
 Template repository for all CGS GitHub repositories


### PR DESCRIPTION
Currently the repo is just using `flake8`. `pre-commit` is a way to run the CI suite in a way that is a bit easier to maintain, and easier to run locally. This should make the git diffs in PRs cleaner if people are using different auto formatters since it autofixes and then recommits to have a standard formatter. (ruff for Python, prettier for JS/HTML)

We can still keep flake8 for the time being since ruff covers almost everything with the exception of a few flake8 rules. 

You can run all of these hooks locally by running `pre-commit` after installing with `pip`