### PR TITLE
ignore ruff cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+.ruff_cache/
 
 # Translations
 *.mo


### PR DESCRIPTION
Ignore .ruff_cache when using the ruff linter.

This generally appears to be ignored anyways even without .gitignore for some reason, (perhaps due to a vscode specific feature) but I think it is good to explicitly ignore it