### PR TITLE
Add reasonable project default vscode settings for python

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "charliermarsh.ruff"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "[python]": {
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "always"
+    },
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  },
+  "python.analysis.typeCheckingMode": "standard",
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true,
+  "files.exclude": {
+    // hide cache folders in every subdirectory
+    "**/__pycache__/": true,
+    "**/.pytest_cache/": true,
+    ".ruff_cache/": true,
+    ".hypothesis/": true,
+  }
+}


### PR DESCRIPTION
I think it makes sense to add a very simple default vscode configuration. If someone is using Python I think they should always be using a formatter and a type checker in their IDE and trying to run autofixes. They should really always have pytest enabled by default as well. I don't think anyone is using `unittest` 

ruff will respect the pyproject.toml config so this setting doesn't enforce a particular linter / formatter style, just rather that it is ran automatically. 

I think everyone uses VSCode so I think this is reasonable. Happy to discuss or close this if not though; not attached to this particularly